### PR TITLE
Improve the Makefile.

### DIFF
--- a/test_suite/Makefile
+++ b/test_suite/Makefile
@@ -12,8 +12,17 @@ BIN_DIR = bin
 TEST_SRCS := $(wildcard $(SRC_DIR)/test_*.cpp)
 TESTS := $(patsubst $(SRC_DIR)/test_%.cpp,%,$(TEST_SRCS))
 
-# Common source files
-COMMON_SRCS = $(filter-out $(INCLUDE_DIR)/table.cpp,$(wildcard $(INCLUDE_DIR)/*.cpp))
+# For each test_X.cpp, check if X.cpp exists in include dir and add it to the build
+TEST_CLASSES := $(patsubst test_%.cpp,%.cpp,$(notdir $(TEST_SRCS)))
+CLASS_SRCS := $(wildcard $(INCLUDE_DIR)/*.cpp)
+TEST_CLASS_SRCS := $(filter $(addprefix $(INCLUDE_DIR)/,$(TEST_CLASSES)),$(CLASS_SRCS))
+
+# Base classes that should always be included
+BASE_CLASSES = player.cpp hand.cpp deck.cpp stack.cpp card.cpp
+BASE_SRCS := $(addprefix $(INCLUDE_DIR)/,$(BASE_CLASSES))
+
+# Combine all source files
+COMMON_SRCS = $(sort $(BASE_SRCS) $(TEST_CLASS_SRCS))
 
 # Create build and bin directories
 $(shell mkdir -p $(BUILD_DIR) $(BIN_DIR))
@@ -22,37 +31,55 @@ $(shell mkdir -p $(BUILD_DIR) $(BIN_DIR))
 COMMON_OBJS = $(COMMON_SRCS:$(INCLUDE_DIR)/%.cpp=$(BUILD_DIR)/%.o)
 
 # Default target
-.PHONY: all clean help
+.PHONY: all clean help test
 all: $(TESTS)
 
 # Pattern rule for common object files
 $(BUILD_DIR)/%.o: $(INCLUDE_DIR)/%.cpp
-	$(CC) $(COMPILER_FLAGS) -c $< -o $@
+	@echo "Compiling $<..."
+	@$(CC) $(COMPILER_FLAGS) -c $< -o $@
 
 # Pattern rule for test object files
 $(BUILD_DIR)/test_%.o: $(SRC_DIR)/test_%.cpp
-	$(CC) $(COMPILER_FLAGS) -c $< -o $@
+	@echo "Compiling test $<..."
+	@$(CC) $(COMPILER_FLAGS) -c $< -o $@
 
 # Pattern rule for test executables
-.SECONDEXPANSION:
-%: $(BUILD_DIR)/test_%.o $(COMMON_OBJS) $$(if $$(findstring table,$$@),$(BUILD_DIR)/table.o)
-	$(CC) $(COMPILER_FLAGS) $^ -o $(BIN_DIR)/$@
-
-# Special case for table.cpp
-$(BUILD_DIR)/table.o: $(INCLUDE_DIR)/table.cpp
-	$(CC) $(COMPILER_FLAGS) -c $< -o $@
+%: $(BUILD_DIR)/test_%.o $(COMMON_OBJS)
+	@echo "Linking $@..."
+	@$(CC) $(COMPILER_FLAGS) $^ -o $(BIN_DIR)/$@
 
 # Clean build artifacts
 clean:
-	rm -rf $(BUILD_DIR)/* $(BIN_DIR)/*
+	@echo "Cleaning build files..."
+	@rm -rf $(BUILD_DIR)/* $(BIN_DIR)/*
 
 # Run all tests
-.PHONY: test
 test: all
 	@echo "Running all tests..."
 	@for test in $(TESTS); do \
 		echo "\nRunning $$test test:"; \
 		$(BIN_DIR)/$$test || exit 1; \
+	done
+
+# Show dependency info for a specific test
+.PHONY: deps-%
+deps-%:
+	@echo "Dependencies for $*:"
+	@echo "  Test source: test_$*.cpp"
+	@echo "  Class source: $(filter %/$*.cpp,$(CLASS_SRCS))"
+	@echo "  Common sources: $(COMMON_SRCS)"
+
+# Show build info
+.PHONY: info
+info:
+	@echo "Detected test files:"
+	@for test in $(TEST_SRCS); do \
+		echo "  $$test"; \
+	done
+	@echo "\nDetected class files:"
+	@for class in $(CLASS_SRCS); do \
+		echo "  $$class"; \
 	done
 
 # Show help
@@ -61,6 +88,8 @@ help:
 	@echo "  all     - Build all test executables"
 	@echo "  clean   - Remove all build artifacts"
 	@echo "  test    - Build and run all tests"
+	@echo "  info    - Show detected test and class files"
+	@echo "  deps-X  - Show dependencies for test X"
 	@echo "  help    - Show this help message"
 	@echo "\nAvailable test targets:"
 	@for test in $(TESTS); do \


### PR DESCRIPTION
Now the Makefile is much smarter! Here's how it works:

  1. For any new class:

```
	# Create your files:
	touch ../include/newclass.h
	touch ../include/newclass.cpp
	touch test_newclass.cpp

	# Build just your new test:
	make newclass

	# Or build everything:
	make
```

  2. The Makefile automatically:

- 	Detects your test_newclass.cpp
- 	Finds the corresponding newclass.cpp in the include directory
- 	Includes all necessary base classes (card, deck, etc.)
- 	Sets up proper dependencies

  3. New debugging commands:

```
	# See what files were detected
	make info

	# See dependencies for a specific test
	make deps-newclass
```

  4. No special cases anymore:

- 	Removed the special handling for table.cpp
- 	Any test_X.cpp will automatically look for and include X.cpp
- 	Base classes (card, deck, etc.) are always included