### PR TITLE
Issue #26 - Create a discard pile class.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@
 # Sublime shit
 *.sublime*
 
+# VS Code shit
+*.json
+
 # Local backup files
 *~
 *.backup
@@ -47,3 +50,4 @@ hand
 player
 stack
 table
+tray

--- a/build_tray.sh
+++ b/build_tray.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+make -C test_suite/ tray
+

--- a/include/hand.cpp
+++ b/include/hand.cpp
@@ -1,40 +1,30 @@
 // hand.cpp
 
+/**
+ * Implementation of player's hand functionality.
+ * Manages individual player's cards and discard operations.
+ */
+
 #include "hand.h"
 
-hand::hand(deck& dckDeck) {refill(dckDeck);}														// Default constructor.
+/**
+ * Creates new hand with HAND_INITIAL_CARDS cards.
+ * Immediately fills hand from deck.
+ */
+hand::hand(deck& dckDeck): selection_container(dckDeck, HAND_INITIAL_CARDS) {refill(dckDeck);}														// Default constructor.
 
-
-const bool hand::isEmpty() const {return mapCards.empty();}											// Informs whether we became out of cards.
-
-const int hand::count() const {return mapCards.size();}												// Returns the current number of cards.
-
-void hand::refill(deck& dckDeck)																	// Takes cards from the pile.
-{
-	int iIndex = 0;																					// Index of card positions.
-	int iMaxCards = dckDeck.count() < HAND_INITIAL_CARDS? dckDeck.count(): HAND_INITIAL_CARDS;		// For when the deck is close to the end.
-
-	std::set<card> setHand;																			// Needed here because a std::map can't sort the values.
-
-	iSelected = 0;																					// Resets card selector.
-
-	for(int i = 0; i < iMaxCards; i++) setHand.insert(dckDeck.pop());								// Sorts the cards popped from the stack.
-
-	for(card crdCard: setHand) mapCards.insert({iIndex++, crdCard});								// Copies them to the definitive container.
-}
-
-void hand::select(const int iIndex) {iSelected = iIndex;}											// Selects a card. You're right: it's only a setter.
-
-card hand::discard()																				// Discards the card pointed to by iSelected.
+/**
+ * Removes and returns selected card.
+ * Shifts remaining cards to maintain consecutive indices.
+ */
+card hand::discard()																																// Discards the card pointed to by iSelected.
 {
 	card crdTemp = mapCards.at(iSelected);
 
-	for(std::map<int, card>::iterator it = mapCards.upper_bound(iSelected); it != mapCards.end(); it++) std::prev(it)->second = it->second;
+	for(std::map<int, card>::iterator it = mapCards.upper_bound(iSelected); it != mapCards.end(); it++) std::prev(it)->second = it->second;			// Shifts remaining cards down.
 
 	mapCards.erase(std::prev(mapCards.end()));
 
 	return crdTemp;
 }
-
-const card& hand::operator[](const int iIndex) {return mapCards.at(iIndex);}						// Subscript operator.
 

--- a/include/hand.h
+++ b/include/hand.h
@@ -1,31 +1,34 @@
 // hand.h
 
+// A player's hand of cards
+
 #ifndef HAND_H
 #define HAND_H
 
-#include <set>
-#include <map>
-
-#include "card.h"
-#include "deck.h"
+#include "selection_container.h"
 
 const int HAND_INITIAL_CARDS = 4;					// Initial amount of cards a player receives.
 
-class hand
+/**
+ * @brief Represents a player's hand of cards
+ * 
+ * Manages a player's current cards, allowing selection and discard operations.
+ * Always maintains HAND_INITIAL_CARDS cards when possible through refills.
+ */
+class hand: public selection_container
 {
 public:
-	hand(deck& dckDeck);							// Default constructor.
-	const bool isEmpty() const;						// Informs whether we became out of cards.
-	const int count() const;						// Returns the current number of cards.
-	void refill(deck& dckDeck);						// Takes cards from the pile.
-	void select(const int iIndex);					// Selects a card.
-	card discard();									// Discards the card pointed to by itSelected.
-	const card& operator[](const int iIndex);		// Subscript operator.
-	
-private:
-	int iSelected;
-	std::map<int, card> mapCards;
-
+    /**
+     * @brief Creates new hand with initial cards from deck
+     * @param dckDeck Source deck to draw cards from
+     */
+    hand(deck& dckDeck);
+     /**
+     * @brief Discards currently selected card
+     * @returns The discarded card
+     * @throws std::out_of_range if no card selected
+     */
+    card discard();
 };
 
 #endif

--- a/include/selection_container.cpp
+++ b/include/selection_container.cpp
@@ -1,0 +1,50 @@
+// selection_container.cpp
+
+/**
+ * Base class implementation for card containers with selection capability.
+ * Provides core functionality for managing and manipulating cards.
+ */
+
+#include "selection_container.h"
+
+/**
+ * Initializes container with specified initial card count.
+ * Does not fill cards immediately - derived classes handle initial fill.
+ */
+selection_container::selection_container(deck& dckDeck, const int iInitial): iInitialCards(iInitial), iSelected(0) {mapCards.clear();}
+
+const bool selection_container::isEmpty() const {return mapCards.empty();}																		// Informs whether we became out of cards.
+
+const int selection_container::count() const {return mapCards.size();}																			// Returns the current number of cards.
+
+void selection_container::select(const int iIndex)																								// Selects a card. You're right: it's only a setter.																					// Selects a card.
+{
+	if (iIndex < 0 || iIndex >= count()) throw std::out_of_range("*** Bad selection *** - Card index out of range.");							// Checks if the index is valid, otherwise throws up.
+	iSelected = iIndex;
+}																		
+
+const card& selection_container::operator[](const int iIndex) {return mapCards.at(iIndex);}														// Subscript operator. Throws up if index is invalid.
+
+/**
+ * Refills container with cards from deck up to initial count.
+ * Cards are sorted before insertion using a temporary set.
+ */
+void selection_container::refill(deck& dckDeck)																									// Takes cards from the pile.
+{
+	int iIndex = 0;																																// Index of card positions.
+	int iMaxCards = std::min(dckDeck.count(), getInitialCards());																				// For when the deck is close to the end.
+
+	std::set<card> setSelectable;																												// Needed here because a std::map can't sort the values.
+
+	iSelected = 0;																																// Resets card selector.
+
+	for(int i = 0; i < iMaxCards; i++) setSelectable.insert(dckDeck.pop());																		// Sorts the cards popped from the stack.
+
+	for(const card& crdCard: setSelectable) mapCards.insert({iIndex++, crdCard});																// Copies them to the definitive container.
+}
+
+const int selection_container::getInitialCards() const																							// Returns initial card count for derived class use.
+{
+    return iInitialCards;
+}
+

--- a/include/selection_container.h
+++ b/include/selection_container.h
@@ -1,0 +1,57 @@
+// selection_container.h
+
+/**
+ * @brief Abstract base class for card containers that support selection
+ * 
+ * Provides common functionality for managing a collection of cards where
+ * individual cards can be selected and manipulated. Used as base class
+ * for both player hands and the central tray.
+ */
+
+#ifndef SELECTION_CONTAINER_H
+#define SELECTION_CONTAINER_H
+
+#include <set>
+#include <map>
+
+#include "card.h"
+#include "deck.h"
+
+class selection_container
+{
+public:
+    /**
+     * @brief Constructs container with initial cards from deck
+     * @param dckDeck Source deck to draw cards from
+     * @param iInitial Number of cards to initially draw
+     */
+    selection_container(deck& dckDeck, const int iInitial);
+    virtual ~selection_container() = default;
+    
+    const bool isEmpty() const;                                     // Informs whether we became out of cards.
+    const int count() const;                                        // Returns the current number of cards.
+    /**
+     * @brief Selects a card at given index
+     * @param iIndex Index of card to select
+     * @throws std::out_of_range if index invalid
+     */
+    void select(const int iIndex);
+    /**
+     * @brief Access card at given index
+     * @param iIndex Index of card to access
+     * @returns Reference to card at index
+     * @throws std::out_of_range if index invalid
+     */
+    const card& operator[](const int iIndex);
+    void refill(deck& dckDeck);                                     // Takes cards from the pile.
+    
+protected:
+    const int iInitialCards;                                        ///< Initial card count for this container
+    int iSelected;                                                  ///< Index of currently selected card
+    std::map<int, card> mapCards;                                   ///< Storage for cards indexed by position
+    const int getInitialCards() const;                              ///< Returns initial card count for derived class use
+
+};
+
+#endif
+

--- a/include/tray.cpp
+++ b/include/tray.cpp
@@ -1,0 +1,15 @@
+// tray.cpp
+
+/**
+ * Implementation of central game tray functionality.
+ * Manages shared cards available for all players.
+ */
+
+#include "tray.h"
+
+/**
+ * Creates new tray with TRAY_INITIAL_CARDS cards.
+ * Immediately fills tray from deck.
+ */
+tray::tray(deck& dckDeck): selection_container(dckDeck, TRAY_INITIAL_CARDS) {refill(dckDeck);}		// Default constructor.
+

--- a/include/tray.h
+++ b/include/tray.h
@@ -1,0 +1,30 @@
+// tray.h
+
+// The discard pile of a game.
+
+#ifndef TRAY_H
+#define TRAY_H
+
+#include "selection_container.h"
+
+const int TRAY_INITIAL_CARDS = 8;					// Initial amount of cards of the tray.
+
+/**
+ * @brief Represents the central discard tray
+ * 
+ * Manages face-up cards available for selection.
+ * Initially contains TRAY_INITIAL_CARDS cards and can grow through player discards.
+ */
+class tray: public selection_container
+{
+public:
+    /**
+     * @brief Creates new tray with initial cards from deck
+     * @param dckDeck Source deck to draw cards from
+     */
+    tray(deck& dckDeck);
+
+};
+
+#endif
+

--- a/test_suite/Makefile
+++ b/test_suite/Makefile
@@ -18,7 +18,7 @@ CLASS_SRCS := $(wildcard $(INCLUDE_DIR)/*.cpp)
 TEST_CLASS_SRCS := $(filter $(addprefix $(INCLUDE_DIR)/,$(TEST_CLASSES)),$(CLASS_SRCS))
 
 # Base classes that should always be included
-BASE_CLASSES = player.cpp hand.cpp deck.cpp stack.cpp card.cpp
+BASE_CLASSES = selection_container.cpp player.cpp hand.cpp deck.cpp stack.cpp card.cpp
 BASE_SRCS := $(addprefix $(INCLUDE_DIR)/,$(BASE_CLASSES))
 
 # Combine all source files

--- a/test_suite/include/output.h
+++ b/test_suite/include/output.h
@@ -12,6 +12,7 @@
 
 #include "../../include/card.h"
 #include "../../include/deck.h"
+#include "../../include/tray.h"
 #include "../../include/hand.h"
 #include "../../include/player.h"
 
@@ -82,6 +83,13 @@ std::ostream& operator<<(std::ostream& osOut, card crdCard)							// Card output
 std::ostream& operator<<(std::ostream& osOut, deck dckDeck)								// Deck output.
 {
     while (!dckDeck.isEmpty()) osOut << dckDeck.pop() << (dckDeck.isEmpty()? "": ", ");
+
+	return osOut;
+}
+
+std::ostream& operator<<(std::ostream& osOut, tray tryTray)								// Tray output.
+{
+	for(int i = 0; i < tryTray.count(); i++) osOut << (i == 0? "": ", ") << tryTray[i];
 
 	return osOut;
 }

--- a/test_suite/test_hand.cpp
+++ b/test_suite/test_hand.cpp
@@ -1,13 +1,116 @@
 // test_hand.cpp
 
+// Program to test the hand class.
+
+#include <stdexcept>															// std::out_of_range
+#include <cassert>																// assert
 #include <iostream>																// std::cout
 
 #include "../include/deck.h"
 #include "../include/hand.h"
 #include "include/output.h"
 
+/**
+ * Tests whether a hand is properly constructed with four cards.
+ *
+ * Checks the hand's size and whether it is empty.
+ */
+void test_hand_construction()
+{
+    deck dckDeck;
+    hand hndHand(dckDeck);
+    
+    assert(hndHand.count() == 4);
+    assert(!hndHand.isEmpty());
+}
+
+/**
+ * Tests whether discarding a card from a hand works correctly.
+ *
+ * Checks the hand's size before and after discarding a card,
+ * and whether the discarded card is a valid card.
+ */
+void test_hand_discard()
+{
+    deck dckDeck;
+    hand hndHand(dckDeck);
+    
+    hndHand.select(0);
+    card crdDiscarded = hndHand.discard();
+    
+    assert(hndHand.count() == 3);
+    assert(crdDiscarded.figure() >= JOKER && crdDiscarded.figure() <= KING);
+}
+
+/**
+ * Tests whether a hand can be properly refilled with four new cards.
+ *
+ * Checks the hand's size before and after refilling.
+ */
+void test_hand_refill()
+{
+    deck dckDeck;
+    hand hndHand(dckDeck);
+    
+    // Discard all cards
+    for(int i = 0; i < 4; i++)
+{
+        hndHand.select(0);
+        hndHand.discard();
+    }
+    
+    assert(hndHand.isEmpty());
+    
+    // Refill
+    hndHand.refill(dckDeck);
+    assert(hndHand.count() == 4);
+}
+
+/**
+ * Tests whether a hand can be properly selected with a valid and invalid index.
+ *
+ * Checks that selecting a card with a valid index works and that selecting a card with an invalid index throws.
+ */
+void test_hand_selection()
+{
+    deck dckDeck;
+    hand hndHand(dckDeck);
+    
+    // Test valid selection
+    hndHand.select(3);
+    
+    // Test invalid selection should throw
+	bool caught = false;
+    try
+	{
+        hndHand.select(4);							                            // Should throw
+	}    
+	catch(const std::out_of_range&)
+	{
+        caught = true;
+    }
+	assert(caught && "test_hand_selection: Expected out_of_range exception");
+}
+
+/**
+ * Runs all tests for the hand class.
+ *
+ * Outputs to the console the name of the test being run, and whether all tests
+ * passed or not.
+ */
 int main()
 {
+    std::cout << "Running hand tests...\n";
+    
+    test_hand_construction();
+    test_hand_discard();
+    test_hand_refill();
+    test_hand_selection();
+    
+    std::cout << "All hand tests passed!\n";
+
+    // Deprecated test: user interaction
+
 	int iChoice = 0;
 
 	deck dckDeck;																// Creates a deck.
@@ -26,4 +129,5 @@ int main()
 
 	return 0;
 }
+
 

--- a/test_suite/test_tray.cpp
+++ b/test_suite/test_tray.cpp
@@ -1,0 +1,117 @@
+// test_tray.cpp
+
+#include <cassert>		// assert
+#include <stdexcept>	// std::out_of_range
+#include <iostream>
+
+#include "../include/deck.h"
+#include "../include/tray.h"
+#include "include/output.h"
+
+/**
+ * Tests whether a tray is properly constructed with the initial amount of cards.
+ *
+ * Checks the tray's size and whether it is empty.
+ */
+void test_tray_construction()
+{
+    deck dckDeck;
+    tray tryTray(dckDeck);
+    
+    assert(tryTray.count() == TRAY_INITIAL_CARDS);
+    assert(!tryTray.isEmpty());
+}
+
+/**
+ * Tests whether the refill behavior of a tray works correctly.
+ *
+ * Verifies that when a tray is refilled, the cards currently in the tray
+ * are not changed.
+ */
+void test_tray_refill_behavior() 
+{
+    deck dckDeck;
+    tray tryTray(dckDeck);
+    
+    // Remember initial cards
+    std::set<card> initialCards;
+    for(int i = 0; i < TRAY_INITIAL_CARDS; i++) 
+	{
+        initialCards.insert(tryTray[i]);
+    }
+    
+    // Refill shouldn't change cards
+    tryTray.refill(dckDeck);
+    
+    // Verify same cards remain
+    for(int i = 0; i < TRAY_INITIAL_CARDS; i++)
+	{
+        assert(initialCards.find(tryTray[i]) != initialCards.end());
+    }
+}
+
+/**
+ * Tests whether a tray can be properly selected with valid and invalid indices.
+ *
+ * Checks that selecting a card with a valid index works and that selecting a card 
+ * with an invalid index throws an out_of_range exception.
+ */
+
+void test_tray_selection()
+{
+    deck dckDeck;
+    tray tryTray(dckDeck);
+    
+    // Valid selection
+    tryTray.select(0);
+    tryTray.select(TRAY_INITIAL_CARDS - 1);
+    
+    // Invalid selection
+    bool caught = false;
+    try
+	{
+        tryTray.select(TRAY_INITIAL_CARDS);
+    }
+	catch(const std::out_of_range&)
+	{
+        caught = true;
+    }
+    assert(caught && "Expected out_of_range exception");
+}
+
+/**
+ * Runs all tests for the tray class.
+ *
+ * Outputs to the console the name of the test being run, and whether all tests
+ * passed or not.
+ */
+
+int main()
+{
+    std::cout << "Running tray tests...\n";
+    
+    test_tray_construction();
+    test_tray_refill_behavior();
+    test_tray_selection();
+    
+    std::cout << "All tray tests passed!\n";
+
+    // Deprecated test: user interaction
+
+	int iChoice = 0;
+
+	deck dckDeck;																// Creates a deck.
+
+	tray tryTray(dckDeck);														// Takes four cards from it.
+
+	std::cout << std::endl << "\t" << tryTray << std::endl << std::endl;		// Shows the tray contents.
+
+	std::cout << "\tPlease choose a card (0 to 7):\t";
+
+	std::cin >> iChoice;
+
+	std::cout << std::endl << std::endl << "\tYou've chosen:\t" << tryTray[iChoice] << std::endl << std::endl;
+ 
+    return 0;
+}
+


### PR DESCRIPTION
    This one was a major commit, affecting lots of structural concerns and files. I skipped TDD this time because I felt the classes deserved better tests, so only in this specific case, tests were created after the classes were written, and I don't intend to do this again in the future. I'm starting to gradually deprecate the old test system but I'm still keeping it for a while because outputting the classes directly to streams has its virtues, and the "output.h" file can come in handy in the future for other purposes than only testing.
    Most functionality (almost all of it) from the `hand` class is now moved to a new `selection_container` base class, leaving behind only the `hand::discard()` method because it's the only method the new `tray` class won't need at all. "Makefile", ".gitignore" and "output.h" were updated and "selection_container.h", "selection_container.cpp", "tray.h", "tray.cpp", "test_tray.cpp" plus "build_tray.sh" were created to accommodate the new classes.
    I'm trying VS Code this time instead of Sublime Text, as an experiment.