### PR TITLE
Issue #36 - Refactor the logic for the discard() method

### DIFF
--- a/include/card.cpp
+++ b/include/card.cpp
@@ -2,21 +2,23 @@
 
 #include "card.h"
 
-card::card(int iFig, int iSt):																						// Constructor definition.
+card::card(int iFig, int iSt):																									// Constructor definition.
 	iFigure((iFig < JOKER || iFig > KING)? throw std::out_of_range("*** Bad card *** - Bad figure!"): iFig),
 	iSuit((iSt < RED || iSt > CLUBS)? throw std::out_of_range("*** Bad card *** - Bad suit!"): iSt) {}
 
-card::card(const card& crdOther): iFigure(crdOther.iFigure), iSuit(crdOther.iSuit) {}								// Copy constructor.
+card::card(const card& crdOther): iFigure(crdOther.iFigure), iSuit(crdOther.iSuit) {}											// Copy constructor.
 
-card& card::operator=(const card& crdOther) {iFigure = crdOther.iFigure; iSuit = crdOther.iSuit; return *this;}		// Assignment operator.
+card& card::operator=(const card& crdOther) {iFigure = crdOther.iFigure; iSuit = crdOther.iSuit; return *this;}					// Assignment operator.
 
-const bool card::operator<(const card& crdOther) const																// Less than operator.
+const bool card::operator<(const card& crdOther) const																			// Less than operator.
 {
 	if(this->suit() == crdOther.suit()) return this->figure() < crdOther.figure();
 
 	return this->suit() < crdOther.suit();
 }
 
-const int card::figure() const {return iFigure;}																	// Getters definitions.
+const bool card::operator==(const card& other) const {return this->iSuit == other.iSuit && this->iFigure == other.iFigure;}		// Equality operator.
+
+const int card::figure() const {return iFigure;}																				// Getters definitions.
 const int card::suit() const {return iSuit;}
 

--- a/include/card.h
+++ b/include/card.h
@@ -18,7 +18,8 @@ public:
 
 	card& operator=(const card& crdOther);					// Assignment operator.
 	const bool operator<(const card& crdOther) const;		// Less than operator.
-
+	const bool operator==(const card& other) const;			// Equality operator.
+	
 	const int figure() const;								// Only getters because you will never need to change a card.
 	const int suit() const;
 	

--- a/include/hand.cpp
+++ b/include/hand.cpp
@@ -6,25 +6,32 @@
  */
 
 #include "hand.h"
+#include "tray.h"
 
 /**
  * Creates new hand with HAND_INITIAL_CARDS cards.
  * Immediately fills hand from deck.
  */
-hand::hand(deck& dckDeck): selection_container(dckDeck, HAND_INITIAL_CARDS) {refill(dckDeck);}													// Default constructor.
+hand::hand(deck& dckDeck): selection_container(dckDeck, HAND_INITIAL_CARDS) {refill(dckDeck);}				// Default constructor.
 
 /**
  * Removes and returns selected card.
  * Shifts remaining cards to maintain consecutive indices.
  */
-card hand::discard()																															// Discards the card pointed to by iSelected.
+card hand::discard()																						// Original version, returns the card
 {
-	card crdTemp = mapCards.at(iSelected);
+	card crdTemp = mapCards.at(iSelected);																	// Stores the selected card.
+	
+	for(std::map<int, card>::iterator it = mapCards.upper_bound(iSelected); it != mapCards.end(); it++)		// Shifts the remaining cards.
+		std::prev(it)->second = it->second;
+		
+	mapCards.erase(std::prev(mapCards.end()));																// Removes the last card.
+	
+	return crdTemp;																							// Returns the selected card.
+}
 
-	for(std::map<int, card>::iterator it = mapCards.upper_bound(iSelected); it != mapCards.end(); it++) std::prev(it)->second = it->second;		// Shifts remaining cards down.
-
-	mapCards.erase(std::prev(mapCards.end()));
-
-	return crdTemp;
+void hand::discard(tray& trayTarget)																		// New version: discards to tray instead of returning the card
+{
+    trayTarget.receive_discard(discard());																	// Reuse original discard logic
 }
 

--- a/include/hand.h
+++ b/include/hand.h
@@ -7,7 +7,9 @@
 
 #include "selection_container.h"
 
-const int HAND_INITIAL_CARDS = 4;        // Initial amount of cards a player receives.
+class tray;                             // Forward declaration to avoid circular dependency
+
+const int HAND_INITIAL_CARDS = 4;       // Initial amount of cards a player receives.
 
 /**
  * @brief Represents a player's hand of cards
@@ -23,12 +25,20 @@ public:
      * @param dckDeck Source deck to draw cards from
      */
     hand(deck& dckDeck);
-     /**
+    
+    /**
      * @brief Discards currently selected card
      * @returns The discarded card
      * @throws std::out_of_range if no card selected
      */
-    card discard();
+    card discard();                     // Original version, returns the card
+    
+    /**
+     * @brief Discards currently selected card to the tray
+     * @param trayTarget Tray to discard card to
+     * @throws std::out_of_range if no card selected
+     */
+    void discard(tray& trayTarget);     // New overloaded version: discards to tray instead of returning the card
 };
 
 #endif

--- a/include/selection_container.cpp
+++ b/include/selection_container.cpp
@@ -11,7 +11,7 @@
  * Initializes container with specified initial card count.
  * Does not fill cards immediately - derived classes handle initial fill.
  */
-selection_container::selection_container(deck& dckDeck, const int iInitial): iInitialCards(iInitial), iSelected(0) {mapCards.clear();}
+selection_container::selection_container(deck& dckDeck, const int iInitial): iInitialCards(iInitial), iSelected(0), mapCards{} {}
 
 const bool selection_container::isEmpty() const {return mapCards.empty();}													// Informs whether we became out of cards.
 
@@ -43,8 +43,5 @@ void selection_container::refill(deck& dckDeck)																				// Takes card
 	for(const card& crdCard: setSelectable) mapCards.insert({iIndex++, crdCard});											// Copies them to the definitive container.
 }
 
-const int selection_container::getInitialCards() const																		// Returns initial card count for derived class use.
-{
-    return iInitialCards;
-}
+const int selection_container::getInitialCards() const {return iInitialCards;}												// Returns initial card count for derived class use.
 

--- a/include/tray.cpp
+++ b/include/tray.cpp
@@ -13,3 +13,5 @@
  */
 tray::tray(deck& dckDeck): selection_container(dckDeck, TRAY_INITIAL_CARDS) {refill(dckDeck);}		// Default constructor.
 
+void tray::receive_discard(const card& crdDiscarded) {mapCards.insert({count(), crdDiscarded});}	// Adds a discarded card to the tray.
+

--- a/include/tray.h
+++ b/include/tray.h
@@ -24,6 +24,12 @@ public:
      */
     tray(deck& dckDeck);
 
+    /**
+     * @brief Adds a discarded card to the tray
+     * @param crdDiscarded Card to add to tray
+     */
+    void receive_discard(const card& crdDiscarded);
+
 };
 
 #endif

--- a/test_suite/test_hand.cpp
+++ b/test_suite/test_hand.cpp
@@ -8,6 +8,7 @@
 
 #include "../include/deck.h"
 #include "../include/hand.h"
+#include "../include/tray.h"
 #include "include/output.h"
 
 /**
@@ -25,24 +26,6 @@ void test_hand_construction()
 }
 
 /**
- * Tests whether discarding a card from a hand works correctly.
- *
- * Checks the hand's size before and after discarding a card,
- * and whether the discarded card is a valid card.
- */
-void test_hand_discard()
-{
-    deck dckDeck;
-    hand hndHand(dckDeck);
-    
-    hndHand.select(0);
-    card crdDiscarded = hndHand.discard();
-    
-    assert(hndHand.count() == 3);
-    assert(crdDiscarded.figure() >= JOKER && crdDiscarded.figure() <= KING);
-}
-
-/**
  * Tests whether a hand can be properly refilled with four new cards.
  *
  * Checks the hand's size before and after refilling.
@@ -52,7 +35,7 @@ void test_hand_refill()
     deck dckDeck;
     hand hndHand(dckDeck);
     
-    // Discard all cards
+    tray tryTray(dckDeck);                                                  // Discard all cards
     for(int i = 0; i < 4; i++)
 {
         hndHand.select(0);
@@ -76,11 +59,9 @@ void test_hand_selection()
     deck dckDeck;
     hand hndHand(dckDeck);
     
-    // Test valid selection
-    hndHand.select(3);
+    hndHand.select(3);                                                      // Test valid selection
     
-    // Test invalid selection should throw
-	bool caught = false;
+	bool caught = false;                                                    // Test invalid selection
     try
 	{
         hndHand.select(4);							                        // Should throw
@@ -90,6 +71,27 @@ void test_hand_selection()
         caught = true;
     }
 	assert(caught && "test_hand_selection: Expected out_of_range exception");
+}
+
+/**
+ * Tests whether discarding a card to tray works correctly.
+ * Verifies card movement from hand to tray.
+ */
+void test_hand_discard_to_tray()
+{
+    deck dckDeck;
+    tray tryTray(dckDeck);
+    hand hndHand(dckDeck);
+    
+    int initialTrayCount = tryTray.count();
+    card expectedCard = hndHand[0];
+    
+    hndHand.select(0);
+    hndHand.discard(tryTray);
+    
+    assert(hndHand.count() == HAND_INITIAL_CARDS - 1);
+    assert(tryTray.count() == initialTrayCount + 1);
+    assert(tryTray[tryTray.count() - 1] == expectedCard);
 }
 
 /**
@@ -103,30 +105,24 @@ int main()
     std::cout << "Running hand tests...\n";
     
     test_hand_construction();
-    test_hand_discard();
     test_hand_refill();
     test_hand_selection();
+    test_hand_discard_to_tray();
     
     std::cout << "All hand tests passed!\n";
 
     // Deprecated test: user interaction
+    int iChoice = 0;
+    deck dckDeck;
+    hand hndHand(dckDeck);
 
-	int iChoice = 0;
+    std::cout << std::endl << "\t" << hndHand << std::endl << std::endl;
+    std::cout << "\tPlease choose a card (0 to 3):\t";
+    std::cin >> iChoice;
 
-	deck dckDeck;													        // Creates a deck.
-
-	hand hndHand(dckDeck);												    // Takes four cards from it.
-
-	std::cout << std::endl << "\t" << hndHand << std::endl << std::endl;    // Shows the hand contents.
-
-	std::cout << "\tPlease choose a card (0 to 3):\t";
-
-	std::cin >> iChoice;
-
-	hndHand.select(iChoice);
-
-	std::cout << std::endl << std::endl << "\tYou've chosen:\t" << hndHand.discard() << std::endl << std::endl;
-
-	return 0;
+    hndHand.select(iChoice);
+    std::cout << std::endl << std::endl << "\tYou've chosen:\t" << hndHand.discard() << std::endl << std::endl;
+ 
+    return 0;
 }
 

--- a/test_suite/test_tray.cpp
+++ b/test_suite/test_tray.cpp
@@ -76,6 +76,24 @@ void test_tray_selection()
 }
 
 /**
+ * Tests whether receiving discarded cards works correctly.
+ * Verifies tray properly stores received cards.
+ */
+void test_tray_receive_discard()
+{
+    deck dckDeck;
+    tray tryTray(dckDeck);
+    
+    int initialCount = tryTray.count();
+    card testCard(HEARTS, ACE);
+    
+    tryTray.receive_discard(testCard);
+    
+    assert(tryTray.count() == initialCount + 1);
+    assert(tryTray[tryTray.count() - 1] == testCard);
+}
+
+/**
  * Runs all tests for the tray class.
  *
  * Outputs to the console the name of the test being run, and whether all tests
@@ -89,6 +107,7 @@ int main()
     test_tray_construction();
     test_tray_refill_behavior();
     test_tray_selection();
+    test_tray_receive_discard();
     
     std::cout << "All tray tests passed!\n";
 
@@ -102,7 +121,7 @@ int main()
 
 	std::cout << std::endl << "\t" << tryTray << std::endl << std::endl;    // Shows the tray contents.
 
-	std::cout << "\tPlease choose a card (0 to 7):\t";
+	std::cout << "\tPlease choose a card (0 to " << tryTray.count() - 1 << "):\t";
 
 	std::cin >> iChoice;
 


### PR DESCRIPTION
It turns out several unforeseen changes were necessary.

- Instead of simply "refactoring", like proposed, a new **overloaded** version of the function was necessary, now, properly a method. The old one was kept, because inner logic of the classes takes advantage of it returning a card, like the `player::steal()` method, for instance, and some tests.
- The `tray` class now has a `tray::receive_discard()` method so to accept discarded cards from the `hand` class.
- The `card` class needed an equality operator for the `test_hand_discard_to_tray()` test.
- For performance reasons, the constructor of `selection_container` now uses curly brace initialisation of `selection_container::mapCards`.

Of course, new tests were created for this new behaviour.