### PR TITLE
63-correct-the-style-of-the-card-class

### DIFF
--- a/include/card.cpp
+++ b/include/card.cpp
@@ -17,7 +17,7 @@ const bool card::operator<(const card& crdOther) const																			// Less
 	return this->suit() < crdOther.suit();
 }
 
-const bool card::operator==(const card& other) const {return this->iSuit == other.iSuit && this->iFigure == other.iFigure;}		// Equality operator.
+const bool card::operator==(const card& crdOther) const {return this->iSuit == crdOther.iSuit && this->iFigure == crdOther.iFigure;}		// Equality operator.
 
 const int card::figure() const {return iFigure;}																				// Getters definitions.
 const int card::suit() const {return iSuit;}

--- a/include/card.h
+++ b/include/card.h
@@ -18,7 +18,7 @@ public:
 
 	card& operator=(const card& crdOther);					// Assignment operator.
 	const bool operator<(const card& crdOther) const;		// Less than operator.
-	const bool operator==(const card& other) const;			// Equality operator.
+	const bool operator==(const card& crdOther) const;		// Equality operator.
 	
 	const int figure() const;								// Only getters because you will never need to change a card.
 	const int suit() const;

--- a/include/table.cpp
+++ b/include/table.cpp
@@ -5,6 +5,6 @@
 table::table(int iPlayers) : tryTray(dckPile) {for(int i = 0; i < iPlayers; i++) plyPlayers.push_back(player(dckPile));}	// Default constructor.
 
 std::vector<player>& table::getPlayers() {return plyPlayers;}																// Getter for the players collection.
-tray& table::getTray() { return tryTray; }																					// Getter for the tray. Can't be const because of the receive_discard method.
-const deck& table::getDeck() const { return dckPile; }
+tray& table::getTray() {return tryTray;}																					// Getter for the tray. Can't be const because of the receive_discard method.
+const deck& table::getDeck() const {return dckPile;}																		// Getter for the deck.
 


### PR DESCRIPTION
Corrected style inconsistencies in `card` an `table` classes. Now Hungarian notation is enforced, as well as curly braces spacing.